### PR TITLE
Add voice mute/unmute and lock/unlock commands

### DIFF
--- a/src/discord/commands/public/voice-lock.ts
+++ b/src/discord/commands/public/voice-lock.ts
@@ -1,0 +1,56 @@
+import { createCommand } from "#base";
+import { ApplicationCommandType, ChannelType } from "discord.js";
+import {
+  channelLockedEmbed,
+  notOwnerOfVoiceChannelEmbed,
+  notVoiceChannelEmbed,
+  sheriffNotConfiguredEmbed,
+} from "#embeds";
+import { prisma } from "#database";
+
+createCommand({
+  name: "voice-lock",
+  description: "Lock the voice channel to prevent new users from joining",
+  type: ApplicationCommandType.ChatInput,
+  async run(interaction) {
+    const channel = interaction.channel;
+
+    if (!channel || channel.type !== ChannelType.GuildVoice) {
+      return interaction.reply({
+        embeds: [notVoiceChannelEmbed],
+        ephemeral: true,
+      });
+    }
+
+    const guildData = await prisma.guild.findUnique({
+      where: { id: interaction.guild.id },
+    });
+
+    if (!guildData) {
+      return interaction.reply({
+        embeds: [sheriffNotConfiguredEmbed],
+        ephemeral: true,
+      });
+    }
+
+    const isOwner =
+      channel.name ===
+      `${interaction.user.username}'s - ${guildData.temporaryChannelComplement}`;
+
+    if (!isOwner) {
+      return interaction.reply({
+        embeds: [notOwnerOfVoiceChannelEmbed],
+        ephemeral: true,
+      });
+    }
+
+    await channel.permissionOverwrites.edit(
+      interaction.guild.roles.everyone,
+      { Connect: false }
+    );
+
+    return interaction.reply({
+      embeds: [channelLockedEmbed],
+    });
+  },
+});

--- a/src/discord/commands/public/voice-mute.ts
+++ b/src/discord/commands/public/voice-mute.ts
@@ -1,0 +1,41 @@
+import { createCommand } from "#base";
+import {
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+} from "discord.js";
+import { userMutedEmbed } from "#embeds";
+import { validateVoiceCommand } from "#functions";
+
+createCommand({
+  name: "voice-mute",
+  description: "Mute a user in the voice channel",
+  type: ApplicationCommandType.ChatInput,
+  options: [
+    {
+      name: "user",
+      description: "User to be muted",
+      type: ApplicationCommandOptionType.User,
+      required: true,
+    },
+  ],
+  async run(interaction) {
+    const { options } = interaction;
+    const user = options.getUser("user", true);
+
+    const validation = await validateVoiceCommand(interaction, user);
+
+    if (!validation.isValid) {
+      return validation.errorReply
+        ? interaction.reply(validation.errorReply)
+        : null;
+    }
+
+    const { member } = validation;
+
+    await member.voice.setMute(true);
+
+    return interaction.reply({
+      embeds: [userMutedEmbed(user)],
+    });
+  },
+});

--- a/src/discord/commands/public/voice-unlock.ts
+++ b/src/discord/commands/public/voice-unlock.ts
@@ -1,0 +1,56 @@
+import { createCommand } from "#base";
+import { ApplicationCommandType, ChannelType } from "discord.js";
+import {
+  channelUnlockedEmbed,
+  notOwnerOfVoiceChannelEmbed,
+  notVoiceChannelEmbed,
+  sheriffNotConfiguredEmbed,
+} from "#embeds";
+import { prisma } from "#database";
+
+createCommand({
+  name: "voice-unlock",
+  description: "Unlock the voice channel allowing new users to join",
+  type: ApplicationCommandType.ChatInput,
+  async run(interaction) {
+    const channel = interaction.channel;
+
+    if (!channel || channel.type !== ChannelType.GuildVoice) {
+      return interaction.reply({
+        embeds: [notVoiceChannelEmbed],
+        ephemeral: true,
+      });
+    }
+
+    const guildData = await prisma.guild.findUnique({
+      where: { id: interaction.guild.id },
+    });
+
+    if (!guildData) {
+      return interaction.reply({
+        embeds: [sheriffNotConfiguredEmbed],
+        ephemeral: true,
+      });
+    }
+
+    const isOwner =
+      channel.name ===
+      `${interaction.user.username}'s - ${guildData.temporaryChannelComplement}`;
+
+    if (!isOwner) {
+      return interaction.reply({
+        embeds: [notOwnerOfVoiceChannelEmbed],
+        ephemeral: true,
+      });
+    }
+
+    await channel.permissionOverwrites.edit(
+      interaction.guild.roles.everyone,
+      { Connect: true }
+    );
+
+    return interaction.reply({
+      embeds: [channelUnlockedEmbed],
+    });
+  },
+});

--- a/src/discord/commands/public/voice-unmute.ts
+++ b/src/discord/commands/public/voice-unmute.ts
@@ -1,0 +1,41 @@
+import { createCommand } from "#base";
+import {
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+} from "discord.js";
+import { userUnmutedEmbed } from "#embeds";
+import { validateVoiceCommand } from "#functions";
+
+createCommand({
+  name: "voice-unmute",
+  description: "Unmute a user in the voice channel",
+  type: ApplicationCommandType.ChatInput,
+  options: [
+    {
+      name: "user",
+      description: "User to be unmuted",
+      type: ApplicationCommandOptionType.User,
+      required: true,
+    },
+  ],
+  async run(interaction) {
+    const { options } = interaction;
+    const user = options.getUser("user", true);
+
+    const validation = await validateVoiceCommand(interaction, user);
+
+    if (!validation.isValid) {
+      return validation.errorReply
+        ? interaction.reply(validation.errorReply)
+        : null;
+    }
+
+    const { member } = validation;
+
+    await member.voice.setMute(false);
+
+    return interaction.reply({
+      embeds: [userUnmutedEmbed(user)],
+    });
+  },
+});

--- a/src/discord/embeds/channel-locked.ts
+++ b/src/discord/embeds/channel-locked.ts
@@ -1,0 +1,8 @@
+import { Colors } from "discord.js";
+import { createEmbed } from "@magicyan/discord";
+
+export const channelLockedEmbed = createEmbed({
+  title: "Channel Locked",
+  description: "This voice channel has been locked to new participants",
+  color: Colors.DarkButNotBlack,
+});

--- a/src/discord/embeds/channel-unlocked.ts
+++ b/src/discord/embeds/channel-unlocked.ts
@@ -1,0 +1,8 @@
+import { Colors } from "discord.js";
+import { createEmbed } from "@magicyan/discord";
+
+export const channelUnlockedEmbed = createEmbed({
+  title: "Channel Unlocked",
+  description: "This voice channel is now open to everyone",
+  color: Colors.DarkButNotBlack,
+});

--- a/src/discord/embeds/index.ts
+++ b/src/discord/embeds/index.ts
@@ -11,3 +11,7 @@ export * from "./limit-denied-booster-user.js";
 export * from "./cannot-target-self.js";
 export * from "./cannot-target-bot.js";
 export * from "./sheriff-not-configured.js";
+export * from "./user-muted.js";
+export * from "./user-unmuted.js";
+export * from "./channel-locked.js";
+export * from "./channel-unlocked.js";

--- a/src/discord/embeds/user-muted.ts
+++ b/src/discord/embeds/user-muted.ts
@@ -1,0 +1,13 @@
+import { Colors, User } from "discord.js";
+import { createEmbed } from "@magicyan/discord";
+
+export const userMutedEmbed = (user: User) =>
+  createEmbed({
+    title: "User Muted",
+    description: `${user.displayName} has been muted in the voice channel`,
+    thumbnail: {
+      url: user.displayAvatarURL({ extension: "png" }),
+      name: user.displayName,
+    },
+    color: Colors.DarkButNotBlack,
+  });

--- a/src/discord/embeds/user-unmuted.ts
+++ b/src/discord/embeds/user-unmuted.ts
@@ -1,0 +1,13 @@
+import { Colors, User } from "discord.js";
+import { createEmbed } from "@magicyan/discord";
+
+export const userUnmutedEmbed = (user: User) =>
+  createEmbed({
+    title: "User Unmuted",
+    description: `${user.displayName} has been unmuted in the voice channel`,
+    thumbnail: {
+      url: user.displayAvatarURL({ extension: "png" }),
+      name: user.displayName,
+    },
+    color: Colors.DarkButNotBlack,
+  });


### PR DESCRIPTION
## Summary
- add `/voice-mute` and `/voice-unmute` commands with corresponding embeds
- add `/voice-lock` and `/voice-unlock` commands and embeds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Module '#database' has no exported member 'Guild' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0f2d184832c948373a4e4a43627